### PR TITLE
Apply target for @atomist/clj-editors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11305,6 +11305,12 @@
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
           "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
+        },
+        "typescript": {
+          "version": "3.5.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+          "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+          "dev": true
         }
       }
     },
@@ -11321,9 +11327,9 @@
       }
     },
     "typescript": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.2.tgz",
+      "integrity": "sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==",
       "dev": true
     },
     "uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -168,9 +168,9 @@
       }
     },
     "@atomist/clj-editors": {
-      "version": "0.8.2-master.20190816115246",
-      "resolved": "https://registry.npmjs.org/@atomist/clj-editors/-/clj-editors-0.8.2-master.20190816115246.tgz",
-      "integrity": "sha512-9x223UcwxYEhuBGVq7H3H5JzdpG81tbog2y4o6oDNpmBzncZ3nKEZwkXUromHaC9TRya0zWVW7HklBdTE5fCsg==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@atomist/clj-editors/-/clj-editors-0.8.2.tgz",
+      "integrity": "sha512-e67AxRCGr8CgUCmNLXeNpX2Plw8x9gZfx3NMKoK4y5ERGPzLe5sbpen3yi0mJuSr750jNDWu0KiBCIj361fPhA==",
       "dev": true,
       "requires": {
         "@cljs-oss/module-deps": "^1.1.1",
@@ -603,10 +603,28 @@
         "lodash": "^4.17.15"
       },
       "dependencies": {
+        "@atomist/clj-editors": {
+          "version": "0.8.2-master.20190816115246",
+          "resolved": "https://registry.npmjs.org/@atomist/clj-editors/-/clj-editors-0.8.2-master.20190816115246.tgz",
+          "integrity": "sha512-9x223UcwxYEhuBGVq7H3H5JzdpG81tbog2y4o6oDNpmBzncZ3nKEZwkXUromHaC9TRya0zWVW7HklBdTE5fCsg==",
+          "dev": true,
+          "requires": {
+            "@cljs-oss/module-deps": "^1.1.1",
+            "semver": "^5.5.0",
+            "xml-js": "^1.6.7",
+            "yargs": "^12.0.1"
+          }
+        },
         "lodash": {
           "version": "4.17.15",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
           "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   },
   "devDependencies": {
     "@atomist/automation-client": "^1.6.2",
-    "@atomist/clj-editors": "0.8.2",
     "@atomist/sdm": "^1.6.1",
     "@atomist/sdm-core": "^1.6.1",
     "@atomist/sdm-local": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "ts-node": "8.2.0",
     "tslint": "^5.17.0",
     "typedoc": "^0.15.0",
-    "typescript": "^3.5.1"
+    "typescript": "^3.6.2"
   },
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@atomist/clj-editors": "0.8.2"
   },
   "devDependencies": {
+    "@atomist/clj-editors": "0.8.2",
     "@atomist/automation-client": "^1.6.2",
     "@atomist/sdm": "^1.6.1",
     "@atomist/sdm-core": "^1.6.1",

--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
     "@atomist/sdm-pack-build": "*",
     "@atomist/sdm-pack-docker": "*",
     "@atomist/slack-messages": "*",
-    "@atomist/clj-editors": ">=0.8.2-master.20190816115246"
+    "@atomist/clj-editors": "0.8.2"
   },
   "devDependencies": {
     "@atomist/automation-client": "^1.6.2",
-    "@atomist/clj-editors": "0.8.2-master.20190816115246",
+    "@atomist/clj-editors": "0.8.2",
     "@atomist/sdm": "^1.6.1",
     "@atomist/sdm-core": "^1.6.1",
     "@atomist/sdm-local": "^1.1.0",


### PR DESCRIPTION
Apply target `npm-project-deps::atomist::clj-editors`:

**New NPM Package Version Update**
Target version for NPM package *@atomist/clj-editors* is `0.8.2`.
Project *atomist/sdm-pack-clojure/atomist/anq2qhoid/typescript-version/master* is currently using version `0.8.2-master.20190816115246`.

_NPM dependencies_
```@atomist/clj-editors (0.8.2)```

---
<details>
  <summary>Tags</summary>
<br/>
<code>[atomist:generated]</code><br/><code>[auto-branch-delete:on-close]</code><br/><code>[auto-merge-method:squash]</code><br/><code>[auto-merge:on-approve]</code><br/><code>[fingerprint:npm-project-deps::atomist::clj-editors=4dfb10f43f862693b355a65626924b3755ddd764ed3bb68110ab4774457dc7ee]</code>
</details>